### PR TITLE
Fix misplaced EOL escape

### DIFF
--- a/_packer
+++ b/_packer
@@ -36,8 +36,8 @@ __build() {
     '-on-error=[(cleanup|abort|ask|run-cleanup-provisioner) If the build fails do: clean up (default), abort, ask, or run-cleanup-provisioner.]' \
     '-parallel-builds=[(1) Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)]' \
     '-timestamp-ui=[Enable prefixing of each ui output with an RFC3339 timestamp.]' \
-    '-var[("key=value")  Variable for templates, can be used multiple times.]'
-    '-var-file=[(path)  JSON or HCL2 file containing user variables.]' \
+    '-var[("key=value")  Variable for templates, can be used multiple times.]' \
+    '-var-file=[(path)  JSON or HCL2 file containing user variables.]'
   __packer_json_templates
 }
 


### PR DESCRIPTION
A misplaced newline escape character caused Zsh to process the last option (`-var-file`) as a command, which resulted in an error when tab-completing. This patch moves the escape to the correct line.